### PR TITLE
Annotate values of given input as collections

### DIFF
--- a/index.ts
+++ b/index.ts
@@ -1,4 +1,4 @@
-function combinate<O extends Record<string | number, any>>(obj: O) {
+function combinate<O extends Record<string | number, any[]>>(obj: O) {
   let combos: { [k in keyof O]: O[k][number] }[] = [];
   for (var key in obj) {
     const values = obj[key];

--- a/test/combinate.test.ts
+++ b/test/combinate.test.ts
@@ -4,12 +4,13 @@ describe("combinate", () => {
   it("generates combinations for an empty object", () => {
     expect(combinate({})).toEqual([]);
   });
+
   it("generates combinations", () => {
-    var obj = {
+    const obj = {
       x: [1, 2, 3],
       y: ["a", "b"],
       z: [20, 30],
-    } as const;
+    };
     const combos = combinate(obj);
     expect(combos).toEqual([
       { x: 1, y: "a", z: 20 },


### PR DESCRIPTION
Hello!

Was checking out this package via your blog and noticed an issue I thought I could potentially help correct in further developing it. Warning: I'm learning TS.

The current implementation annotates the exported combinate function's signature as an object that should conform to an extension of the Record type, where the keys can be either strings or numbers, but the values can be anything (`any`). This seems problematic as the combinate function attempts to iterate through each key's value as though it were an array. This can lead to some funny/unintended outcomes for relatively innocent mistakes on a consumer's part.

e.g. if a key has a single value and someone forgets to wrap it in an array, it will interpret each character as a value as strings are array-ish:
```
const obj = {
    first: 'wat',
    second: ['yay!']
}

combinate(obj)
> 
[
  { first: 'w', second: 'yay!' },
  { first: 'a', second: 'yay!' },
  { first: 't', second: 'yay!' }
]
```
Or if a value is an object, it will just be skipped since `i < obj.length` will always evaluate to `i < undefined` (false)
```
const obj = {
    first: {whoops: 'value'},
    second: ['yay!']
}

combinate(obj)
> 
[
  { second: 'yay!' }
]
```

While the README provides clear instructions on the expected shape of the input value, it might be nice to protect/help users of the library by validating the input at runtime (perhaps via one of the new-ish [assert fns/type guards](https://www.typescriptlang.org/docs/handbook/release-notes/typescript-3-7.html#assertion-functions)?) and throwing a friendly error instead of these unintended outcomes (or a nasty type error). If you agree, I could send a follow up PR for that?

Cheers!